### PR TITLE
Refactor twai driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arduino Library for the ESP32 TWAI (CAN Bus)
 
-This is a library to use the TWAI[^1] (CAN Bus) interface of the ESP32. 
-The library did not use the registry commands to configure the TWAI peripheral, but used the functions from the Espressif IDF to configure the TWAI peripheral, which are more reliable. 
+This is a library to use the TWAI[^1] (CAN Bus) interface of the ESP32.
+The library did not use the registry commands to configure the TWAI peripheral, but used the functions from the Espressif IDF to configure the TWAI peripheral, which are more reliable.
 
 ## Features
 * Easily configure the ESP32 TWAI peripheral
@@ -10,14 +10,34 @@ The library did not use the registry commands to configure the TWAI peripheral, 
 * Send and receive CAN Bus messages
 
 ## Usage
-Starting the TWAI periphery<br>
-`CAN.begin(GPIO_NUM_5,GPIO_NUM_4,TWAI_SPEED_500KBPS)`
+Starting the TWAI periphery with default settings:<br>
+```C++
+CAN.begin(CAN_GPIO_RX, CAN_GPIO_TX, can::Baudrate::BAUD_500KBPS)
+```
+
+or with custom settings:<br>
+```C++
+constexpr std::gpio_num_t CAN_GPIO_RX {GPIO_NUM_5};
+constexpr std::gpio_num_t CAN_GPIO_TX {GPIO_NUM_4};
+constexpr bool CAN_ENABLE_ALERTS {true};
+constexpr std::size_t CAN_RX_QUEUE_LENGTH {10};
+constexpr std::size_t CAN_TX_QUEUE_LENGTH {10};
+
+CAN.begin(CAN_GPIO_RX,
+          CAN_GPIO_TX,
+          can::Baudrate::BAUD_500KBPS,
+          CAN_ENABLE_ALERTS,
+          CAN_RX_QUEUE_LENGTH,
+          CAN_TX_QUEUE_LENGTH);
+```
 
 Send Message<br>
-`CAN.write(TWAI_STD_FRAME,identifier,length,buffer)`
+```C++
+CAN.write(esp32::can::FrameType::STD_FRAME, identifier, length, buffer)
+```
 
 ## Espressif IDF Documentation
-The Espressif IDF documentation at the link below should be reference first if you encounter any errors. Make sure you are using the most recent IDF version when writing this. 
+The Espressif IDF documentation at the link below should be reference first if you encounter any errors. Make sure you are using the most recent IDF version when reading this.
 
 https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/twai.html
 

--- a/library.json
+++ b/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "ESP32-TWAI",
+  "description": "Arduino Library for the ESP32 TWAI (CAN Bus)",
+  "keywords": "ESP32, CAN, TWAI",
+  "authors": [
+      {
+          "name": "Tobias Himmler",
+          "maintainer": true
+      }
+  ],
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/shining-man/ESP32-TWAI"
+  },
+  "version": "1.0.0",
+  "frameworks": "Arduino",
+  "build": {
+    "unflags": [
+        "-std=gnu++11",
+        "-std=gnu99"
+    ],
+    "flags":  [
+      "-std=gnu++2a",
+      "-std=gnu11"
+    ]
+}
+}

--- a/src/ESP32TWAI.cpp
+++ b/src/ESP32TWAI.cpp
@@ -182,10 +182,3 @@ std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
 
   return Stringify(_lastErrorFunction).append(esp_err_to_name(errNo));
 }
-
-/*static*/ ESP32TWAISingleton& ESP32TWAISingleton::instance()
-{
-  static ESP32TWAISingleton instance;
-
-  return instance;
-}

--- a/src/ESP32TWAI.cpp
+++ b/src/ESP32TWAI.cpp
@@ -155,7 +155,7 @@ twai_status_info_t ESP32TWAI::getStatus() const
 
 std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
 {
-  auto Stringify = [](DriverStatus status) constexpr
+  auto Stringify = [](DriverStatus status)
   {
     switch(status)
     {
@@ -175,13 +175,15 @@ std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
         return std::string("TWAI SPEED: ");
       case DriverStatus::STATUS:
         return std::string("TWAI STATUS: ");
+      default:
+        return std::string(); // Return empty string
     }
   };
 
   return Stringify(_lastErrorFunction).append(esp_err_to_name(errNo));
 }
 
-/*static*/ inline ESP32TWAISingleton& ESP32TWAISingleton::instance()
+/*static*/ ESP32TWAISingleton& ESP32TWAISingleton::instance()
 {
   static ESP32TWAISingleton instance;
 

--- a/src/ESP32TWAI.cpp
+++ b/src/ESP32TWAI.cpp
@@ -9,8 +9,6 @@
 #include <string.h> // memcpy
 #include "ESP32TWAI.h"
 
-namespace esp32
-{
 namespace can
 {
 
@@ -187,4 +185,3 @@ std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
 }
 
 } // namespace can
-} // namespace esp32

--- a/src/ESP32TWAI.cpp
+++ b/src/ESP32TWAI.cpp
@@ -15,7 +15,7 @@ namespace can
 {
 
 ESP32TWAI::ESP32TWAI() :
-  _lastErrorFunction(DriverStatus::INIT)
+  _lastErrorFunction(DriverStatus::NONE)
 {
 }
 
@@ -177,8 +177,9 @@ std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
         return std::string("TWAI SPEED: ");
       case DriverStatus::STATUS:
         return std::string("TWAI STATUS: ");
+      case DriverStatus::NONE:
       default:
-        return std::string(); // Return empty string
+        return std::string("UNKNOWN"); // No driver call executed yet.
     }
   };
 

--- a/src/ESP32TWAI.cpp
+++ b/src/ESP32TWAI.cpp
@@ -4,9 +4,15 @@
 // https://opensource.org/licenses/MIT
 
 #include <cassert>
-#include <array> // std::size
+#include <array>    // std::size
+#include <string>
 #include <string.h> // memcpy
 #include "ESP32TWAI.h"
+
+namespace esp32
+{
+namespace can
+{
 
 ESP32TWAI::ESP32TWAI() :
   _lastErrorFunction(DriverStatus::INIT)
@@ -20,7 +26,7 @@ ESP32TWAI::~ESP32TWAI()
 
 esp_err_t ESP32TWAI::begin(gpio_num_t rxPin,
                            gpio_num_t txPin,
-                           TWAI_speed_s baud,
+                           Baudrate baud,
                            bool enableAlerts,
                            std::size_t rxQueueLength,
                            std::size_t txQueueLength)
@@ -36,27 +42,23 @@ esp_err_t ESP32TWAI::begin(gpio_num_t rxPin,
 
   switch(baud)
   {
-    case TWAI_SPEED_100KBPS:
+    case Baudrate::BAUD_100KBPS:
       configTiming = TWAI_TIMING_CONFIG_100KBITS();
       break;
-    case TWAI_SPEED_125KBPS:
+    case Baudrate::BAUD_125KBPS:
      configTiming = TWAI_TIMING_CONFIG_125KBITS();
       break;
-    case TWAI_SPEED_250KBPS:
+    case Baudrate::BAUD_250KBPS:
       configTiming = TWAI_TIMING_CONFIG_250KBITS();
       break;
-    case TWAI_SPEED_500KBPS:
+    case Baudrate::BAUD_500KBPS:
       configTiming = TWAI_TIMING_CONFIG_500KBITS();
       break;
-    case TWAI_SPEED_800KBPS:
+    case Baudrate::BAUD_800KBPS:
       configTiming = TWAI_TIMING_CONFIG_800KBITS();
       break;
-    case TWAI_SPEED_1MBPS:
+    case Baudrate::BAUD_1MBPS:
       configTiming = TWAI_TIMING_CONFIG_1MBITS();
-      break;
-    default:
-      _lastErrorFunction = DriverStatus::SPEED;
-      return ESP_ERR_NOT_SUPPORTED;
       break;
   }
 
@@ -80,12 +82,12 @@ esp_err_t ESP32TWAI::stop()
   return twai_driver_uninstall();
 }
 
-esp_err_t ESP32TWAI::write(TWAI_frame_type_s extd, uint32_t identifier, uint8_t length, uint8_t *buffer)
+esp_err_t ESP32TWAI::write(FrameType extd, uint32_t identifier, uint8_t length, uint8_t *buffer)
 {
   twai_message_t tx_frame {};
   tx_frame.rtr = 0;
   tx_frame.flags = 0;
-  tx_frame.extd = extd;                  // 0=11bit, 1=29bit
+  tx_frame.extd = (extd == FrameType::EXTD_FRAME) ? 1 : 0; // 0=11bit, 1=29bit
   tx_frame.data_length_code = length;
   tx_frame.identifier = identifier;
 
@@ -182,3 +184,6 @@ std::string ESP32TWAI::getErrorText(esp_err_t errNo) const
 
   return Stringify(_lastErrorFunction).append(esp_err_to_name(errNo));
 }
+
+} // namespace can
+} // namespace esp32

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -79,8 +79,8 @@ class ESP32TWAISingleton :
 {
   // Make this class non-copyable, it`s a singleton
   public:
-    ESP32TWAISingleton(const ESP32TWAI& other) = delete;
-    ESP32TWAISingleton& operator=(const ESP32TWAI& other) = delete;
+    ESP32TWAISingleton(const ESP32TWAISingleton& other) = delete;
+    ESP32TWAISingleton& operator=(const ESP32TWAISingleton& other) = delete;
 
     /** Returns the singleton instance (static) of the ESP32TWAISingleton. */
     static ESP32TWAISingleton& instance();

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -55,7 +55,7 @@ class ESP32TWAI
   private:
     enum class DriverStatus : uint8_t
     {
-      INIT           = 0x0,
+      NONE           = 0x0,
       DRIVER_INSTALL = 0x1,
       START          = 0x2,
       STOP           = 0x3,

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -11,8 +11,6 @@
 #include <driver/gpio.h>
 #include <driver/twai.h>
 
-namespace esp32
-{
 namespace can
 {
 
@@ -73,6 +71,5 @@ class ESP32TWAI
 };
 
 } // namespace can
-} // namespace esp32
 
 #endif

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -1,62 +1,92 @@
 // Copyright (c) 2023 Tobias Himmler
-// 
+//
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
 #ifndef INC_ESP32TWAI_H
 #define INC_ESP32TWAI_H
 
-#include <Arduino.h>
-#include "driver/gpio.h"
-#include "driver/twai.h"
+#include <cstddef>
+#include <string>
+#include <driver/gpio.h>
+#include <driver/twai.h>
 
 
-#define ESP32TWAI_STAT_DRIVER_INSTALL   0x1
-#define ESP32TWAI_STAT_START            0x2
-#define ESP32TWAI_STAT_STOP             0x3
-#define ESP32TWAI_STAT_UNINSTALL        0x4
-#define ESP32TWAI_STAT_TRANSMIT         0x5
-#define ESP32TWAI_STAT_RECEIVE          0x6
-#define ESP32TWAI_STAT_SPEED            0x7
-#define ESP32TWAI_STAT_STATUS           0x8
-
-
-typedef enum
+enum TWAI_speed_s
 {
   TWAI_SPEED_100KBPS = 100,
   TWAI_SPEED_125KBPS = 125,
   TWAI_SPEED_250KBPS = 250,
   TWAI_SPEED_500KBPS = 500,
   TWAI_SPEED_800KBPS = 800,
-  TWAI_SPEED_1MBPS   = 1000,
-} TWAI_speed_s;
+  TWAI_SPEED_1MBPS   = 1000
+};
 
-typedef enum
+enum TWAI_frame_type_s
 {
-  TWAI_STD_FRAME = 0,
-  TWAI_EXTD_FRAME = 1,
-} TWAI_frame_type_s;
-
+  TWAI_STD_FRAME  = 0,
+  TWAI_EXTD_FRAME = 1
+};
 
 class ESP32TWAI
 {
+  // Make this class non-copyable, because it`s a singleton
   public:
-    esp_err_t begin(gpio_num_t rxPin, gpio_num_t txPin, TWAI_speed_s baud);
-    void      setAlert(bool alert);
-    void      setRxQueueLen(uint8_t rxQueueLen);
-    esp_err_t stop();
-    esp_err_t write(TWAI_frame_type_s extd, uint32_t identifier, uint8_t length, uint8_t *buffer);
-    esp_err_t read(twai_message_t* ptr_message);
-    uint32_t  getAlert();
-    twai_status_info_t getStatus();
-    String    getErrorText(esp_err_t errNo);
-  
-  private:
+    ESP32TWAI(const ESP32TWAI& other) = delete;
+    ESP32TWAI& operator=(const ESP32TWAI& other) = delete;
 
+  public:
+    /** Returns the singleton instance (static) of the ESP32TWAI. */
+    static ESP32TWAI& getInstance();
+
+    esp_err_t   begin(gpio_num_t rxPin, gpio_num_t txPin, TWAI_speed_s baud);
+    void        setAlert(bool alert);
+    void        setRxQueueLen(std::size_t rxQueueLen);
+    esp_err_t   stop();
+    esp_err_t   write(TWAI_frame_type_s extd, uint32_t identifier, uint8_t length, uint8_t *buffer);
+    esp_err_t   read(twai_message_t* ptr_message);
+    uint32_t    getAlert() const;
+    twai_status_info_t getStatus() const;
+    std::string getErrorText(esp_err_t errNo) const;
+
+  private:
+    enum class DriverStatus : uint8_t
+    {
+      INIT           = 0x0,
+      DRIVER_INSTALL = 0x1,
+      START          = 0x2,
+      STOP           = 0x3,
+      UNINSTALL      = 0x4,
+      TRANSMIT       = 0x5,
+      RECEIVE        = 0x6,
+      SPEED          = 0x7,
+      STATUS         = 0x8
+    };
+    using DriverStatus = ESP32TWAI::DriverStatus;
+
+  private:
+    // This is a Singleton, we do not allow to create an instance from outside the class!
+    ESP32TWAI();
+    ~ESP32TWAI();
+
+  private:
+    static constexpr std::size_t RX_QUEUE_LENGTH_DEFAULT = 5;
+    static constexpr std::size_t TX_QUEUE_LENGTH_DEFAULT = 10;
+    bool _alertsEnabled =false;
+    DriverStatus _lastErrorFunction;
+    std::size_t _rxQueueLen;
 };
 
-
-extern ESP32TWAI CAN;
+/**
+ * The following #define can be used to access the singleton object of the ESP32TWAI.
+ * The getInstance() methods takes care to create the object on the first call.
+ * @code
+ * CAN.begin(GPIO_NUM_5,GPIO_NUM_4,TWAI_SPEED_250KBPS);
+ * twai_status_info_t canStatus = CAN.getStatus();
+ * @endcode
+ *
+*/
+#define CAN (ESP32TWAI::getInstance())
 
 #endif
 

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -11,27 +11,29 @@
 #include <driver/gpio.h>
 #include <driver/twai.h>
 
-// TODO: Would be nice to put this module into an own namespce
-
-enum TWAI_speed_s
+namespace esp32
 {
-  TWAI_SPEED_100KBPS = 100,
-  TWAI_SPEED_125KBPS = 125,
-  TWAI_SPEED_250KBPS = 250,
-  TWAI_SPEED_500KBPS = 500,
-  TWAI_SPEED_800KBPS = 800,
-  TWAI_SPEED_1MBPS   = 1000
+namespace can
+{
+
+enum class Baudrate
+{
+  BAUD_100KBPS = 100,
+  BAUD_125KBPS = 125,
+  BAUD_250KBPS = 250,
+  BAUD_500KBPS = 500,
+  BAUD_800KBPS = 800,
+  BAUD_1MBPS   = 1000
 };
 
-enum TWAI_frame_type_s
+enum class FrameType
 {
-  TWAI_STD_FRAME  = 0,
-  TWAI_EXTD_FRAME = 1
+  STD_FRAME  = 0,
+  EXTD_FRAME = 1
 };
 
 class ESP32TWAI
 {
-
   public:
     ESP32TWAI();
     ~ESP32TWAI();
@@ -39,12 +41,12 @@ class ESP32TWAI
   public:
     esp_err_t begin(gpio_num_t rxPin,
                     gpio_num_t txPin,
-                    TWAI_speed_s baud,
+                    Baudrate baud,
                     bool enableAlerts = false,
                     std::size_t rxQueueLength = RX_QUEUE_LENGTH_DEFAULT,
                     std::size_t txQueueLength = TX_QUEUE_LENGTH_DEFAULT);
     esp_err_t   stop();
-    esp_err_t   write(TWAI_frame_type_s extd, uint32_t identifier, uint8_t length, uint8_t *buffer);
+    esp_err_t   write(FrameType extd, uint32_t identifier, uint8_t length, uint8_t *buffer);
     esp_err_t   read(twai_message_t* ptr_message);
     uint32_t    getAlert() const;
     twai_status_info_t getStatus() const;
@@ -63,12 +65,14 @@ class ESP32TWAI
       SPEED          = 0x7,
       STATUS         = 0x8
     };
-    using DriverStatus = ESP32TWAI::DriverStatus;
 
   private:
     static constexpr std::size_t RX_QUEUE_LENGTH_DEFAULT {5};
     static constexpr std::size_t TX_QUEUE_LENGTH_DEFAULT {5};
     DriverStatus _lastErrorFunction;
 };
+
+} // namespace can
+} // namespace esp32
 
 #endif

--- a/src/ESP32TWAI.h
+++ b/src/ESP32TWAI.h
@@ -71,37 +71,4 @@ class ESP32TWAI
     DriverStatus _lastErrorFunction;
 };
 
-/**
- * Provide a singleton wrapper for the ESP32TWAI class to support the legacy code.
-*/
-class ESP32TWAISingleton :
-  public ESP32TWAI
-{
-  // Make this class non-copyable, it`s a singleton
-  public:
-    ESP32TWAISingleton(const ESP32TWAISingleton& other) = delete;
-    ESP32TWAISingleton& operator=(const ESP32TWAISingleton& other) = delete;
-
-    /** Returns the singleton instance (static) of the ESP32TWAISingleton. */
-    static ESP32TWAISingleton& instance();
-
-  private:
-    // don't allow public construct/destruct
-    ESP32TWAISingleton() = default;
-    ~ESP32TWAISingleton() = default;
-};
-
-/**
- * The following #define can be used to access the singleton object of the ESP32TWAI.
- * The getInstance() methods takes care to create the object on the first call.
- * @code
- * CAN.begin(GPIO_NUM_5,GPIO_NUM_4,TWAI_SPEED_250KBPS);
- * twai_status_info_t canStatus = CAN.getStatus();
- * @endcode
- *
-*/
-#define CAN (ESP32TWAISingleton::instance())
-
 #endif
-
-

--- a/src/ESP32TWAISingleton.hpp
+++ b/src/ESP32TWAISingleton.hpp
@@ -8,22 +8,15 @@
 
 #include <ESP32TWAI.h>
 
-namespace esp32
-{
 namespace can
 {
 
 /**
- * Provide a simple singleton wrapper for the ESP32TWAI class to support legacy code,
+ * A simple singleton wrapper for the ESP32TWAI class to support legacy code,
  * where global access to the ESP32TWAI class is required.
  * @note If possible, don´t use the singleton, use some kind of dependency injection instead.
  * The #define "CAN" can be used as an "alias" to access the singleton object of the ESP32TWAI.
- * @code
- * CAN.begin(GPIO_NUM_5,GPIO_NUM_4,TWAI_SPEED_250KBPS);
- * twai_status_info_t canStatus = CAN.getStatus();
- * @endcode
- *
-*/
+ */
 class ESP32TWAISingleton :
   public ESP32TWAI
 {
@@ -48,8 +41,7 @@ class ESP32TWAISingleton :
 };
 
 } // namespace can
-} // namespace esp32
 
-#define CAN (esp32::can::ESP32TWAISingleton::getInstance())
+#define CAN (can::ESP32TWAISingleton::getInstance())
 
 #endif // INC_ESP32TWAISINGLETON_H

--- a/src/ESP32TWAISingleton.hpp
+++ b/src/ESP32TWAISingleton.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 Meik Jaeckle
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+#ifndef INC_ESP32TWAISINGLETON_H
+#define INC_ESP32TWAISINGLETON_H
+
+#include <ESP32TWAI.h>
+
+// TODO: Would be nice to put this module into an own namespce
+
+/**
+ * Provide a simple singleton wrapper for the ESP32TWAI class to support legacy code,
+ * where global access to the ESP32TWAI class is required.
+ * @note If possible, don´t use the singleton, use some kind of dependency injection instead.
+ * The #define "CAN" can be used as an "alias" to access the singleton object of the ESP32TWAI.
+ * @code
+ * CAN.begin(GPIO_NUM_5,GPIO_NUM_4,TWAI_SPEED_250KBPS);
+ * twai_status_info_t canStatus = CAN.getStatus();
+ * @endcode
+ *
+*/
+class ESP32TWAISingleton :
+  public ESP32TWAI
+{
+  private:
+    // don't allow public construct/destruction
+    ESP32TWAISingleton()  = default;
+    ~ESP32TWAISingleton() = default;
+
+  // Make this class non-copyable, it`s a singleton
+  public:
+    ESP32TWAISingleton(const ESP32TWAISingleton& other) = delete;
+    ESP32TWAISingleton& operator=(const ESP32TWAISingleton& other) = delete;
+
+    /** Returns the singleton instance (static) of the ESP32TWAISingleton.
+     *  The instance is created on the first call to getInstance.
+    */
+    static ESP32TWAISingleton& getInstance()
+    {
+      static ESP32TWAISingleton instance;
+      return instance;
+    }
+};
+
+#define CAN (ESP32TWAISingleton::getInstance())
+
+#endif // INC_ESP32TWAISINGLETON_H

--- a/src/ESP32TWAISingleton.hpp
+++ b/src/ESP32TWAISingleton.hpp
@@ -8,7 +8,10 @@
 
 #include <ESP32TWAI.h>
 
-// TODO: Would be nice to put this module into an own namespce
+namespace esp32
+{
+namespace can
+{
 
 /**
  * Provide a simple singleton wrapper for the ESP32TWAI class to support legacy code,
@@ -44,6 +47,9 @@ class ESP32TWAISingleton :
     }
 };
 
-#define CAN (ESP32TWAISingleton::getInstance())
+} // namespace can
+} // namespace esp32
+
+#define CAN (esp32::can::ESP32TWAISingleton::getInstance())
 
 #endif // INC_ESP32TWAISINGLETON_H


### PR DESCRIPTION
The main purpose of the PR was to add a singleton pattern for the ESP32TWAI driver class.
In the previous implementation, it is not clear, at what time all the instances are created. With the singleton, we have more control over that. I would also suggest, to get rid of the singleton later on, but therefore some more refactoring is required in the application.

Additionally i refactored the ESP32TWAI class a bit. Following are the main changes:
- Use enum class for the ESP32TWAI_STAT_ values instead of #define
- Use enum class for frame type and speed
- Added library.json file to be able to provide required compiler flags
- Use std::string instead of String to get rid of Arduino dependency.

**NOTE**: This is a braking change. I updated the bsc_fw application as well in my branch https://github.com/meikjaeckle/bsc_fw/tree/refactor-twai-driver. If this PR is merged, the PR for the application must be merged as well.